### PR TITLE
BUGFIX: Categories button in ModelAdmin was labelled Calendars

### DIFF
--- a/code/admin/CalendarAdmin.php
+++ b/code/admin/CalendarAdmin.php
@@ -21,7 +21,8 @@ class CalendarAdmin extends LeftAndMain {
 		'ComingEventsForm',
 		'PastEventsForm',
 		'CalendarsForm',
-		'CategoriesForm'
+		'CategoriesForm',
+		'categories'
 	);	
 	
 	

--- a/templates/Includes/CalendarAdmin_Tools.ss
+++ b/templates/Includes/CalendarAdmin_Tools.ss
@@ -20,9 +20,9 @@
 			<% end_if %>
 		<% end_if %>
 		<% if $CategoriesEnabled %>
-			<% if $Action != "calendars" %>
+			<% if $Action != "categories" %>
 				<div style="margin-bottom:5px;">
-					<a href="{$Link}calendars/" class="ss-ui-button ss-ui-action-constructive cms-panel-link ui-corner-all">Calendars</a>
+					<a href="{$Link}categories/" class="ss-ui-button ss-ui-action-constructive cms-panel-link ui-corner-all">Categories</a>
 				</div>
 			<% end_if %>
 		<% end_if %>


### PR DESCRIPTION
There are currently duplicate Calendars button and no working Categories button.
