### PR TITLE
Remove Events tab from edit page of Calendar and Category

### DIFF
--- a/code/calendars/Calendar.php
+++ b/code/calendars/Calendar.php
@@ -21,4 +21,11 @@ class Calendar extends DataObject {
 	private static $summary_fields = array(
 		'Title' => 'Title',
 	);
+
+	public function getCMSFields() {
+		$fields = parent::getCMSFields();
+		$fields->removeByName('Events');
+		return $fields;
+	}
+
 }

--- a/code/categories/EventCategory.php
+++ b/code/categories/EventCategory.php
@@ -29,4 +29,11 @@ class EventCategory extends DataObject {
 		$this->extend('updateAddNewFields', $fields);
 		return $fields;
 	}
+
+	public function getCMSFields() {
+		$fields = parent::getCMSFields();
+		$fields->removeByName('Events');
+		return $fields;
+	}
+
 }


### PR DESCRIPTION
The events tab in the Calendar/Category admin seemed to be incompatible with the main Events admin & was unnecessary. This removes the Events tab so they can only be added/edited where expected.
