### PR TITLE
Fixed typographical error, changed adminstration to administration in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ time picker and dropdown, and duration dropdown, still allowing manual inputs
 
 ## Weak points at the moment
 
-* The event model and adminstration is solid, but is missing recurring events
+* The event model and administration is solid, but is missing recurring events
 	* See the bottom of this readme file for our "wishlist"
 * Frontend templates
 	* The demo is overwriting much of the templates in the calendar


### PR DESCRIPTION
@titledk, I've corrected a typographical error in the documentation of the [silverstripe-calendar](https://github.com/titledk/silverstripe-calendar) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.