### PR TITLE
Tki event fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/code/events/Event.php
+++ b/code/events/Event.php
@@ -141,7 +141,7 @@ class Event extends DataObject
 
         if (isset($this->EndDateTime)) {
             if (strtotime($this->EndDateTime) < strtotime($this->StartDateTime)) {
-                $this->EndDateTime = $this->StarDateTime;
+                $this->EndDateTime = $this->StartDateTime;
                 $this->AllDay = true;
                 $msg = "Sanity check 2: Setting end date = start date and setting all day \n"
                 . "as {$this->EndDateTime} was lower than {$this->StartDateTime} \n"


### PR DESCRIPTION
In Event::onBeforeWrite, the EndDateTime is not set in certain situations, and ends up NULL. For example, if an event with a start time is changed to an all day event. Affects 'Sanity check 2'.