### PR TITLE
Added Subsites support

### DIFF
--- a/code/core/CalendarConfig.php
+++ b/code/core/CalendarConfig.php
@@ -53,6 +53,7 @@ class CalendarConfig
                 'calendarview' => true, //fullcalendar
                 'search' => true,
                 'index' => 'eventlist',
+				'controllerUrl' => '/fullcalendar/',
                 'fullcalendar_js_settings' => "
 					header: {
 						left: 'prev, next',

--- a/code/core/CalendarConfig.php
+++ b/code/core/CalendarConfig.php
@@ -53,7 +53,7 @@ class CalendarConfig
                 'calendarview' => true, //fullcalendar
                 'search' => true,
                 'index' => 'eventlist',
-				'controllerUrl' => '/fullcalendar/',
+                'controllerUrl' => '/fullcalendar/',
                 'fullcalendar_js_settings' => "
 					header: {
 						left: 'prev, next',

--- a/code/core/CalendarHelper.php
+++ b/code/core/CalendarHelper.php
@@ -85,4 +85,34 @@ class CalendarHelper
 
         return $events;
     }
+	
+	
+	/**
+	 * If applicable, adds preview parameters. ie. CMSPreview and SubsiteID.
+	 * @param type $link
+	 * @return type
+	 */
+	public static function add_preview_params($link,$object)
+	{
+		// Pass through if not logged in
+		if(!Member::currentUserID()) {
+			return $link;
+		}
+		$modifiedLink = '';
+		$request = Controller::curr()->getRequest();
+		if ($request && $request->getVar('CMSPreview')) {
+			// Preserve the preview param for further links
+			$modifiedLink = HTTP::setGetVar('CMSPreview', 1, $link);
+			// Quick fix - multiple uses of setGetVar method double escape the ampersands
+			$modifiedLink = str_replace('&amp;','&',$modifiedLink); 
+			// Add SubsiteID, if applicable
+			if (!empty($object->SubsiteID)) {
+				$modifiedLink = HTTP::setGetVar('SubsiteID', $object->SubsiteID, $modifiedLink);
+				// Quick fix - multiple uses of setGetVar method double escape the ampersands
+				$modifiedLink = str_replace('&amp;','&',$modifiedLink); 
+			}
+		} 
+   
+		return ($modifiedLink) ? $modifiedLink : $link;
+	}
 }

--- a/code/core/CalendarHelper.php
+++ b/code/core/CalendarHelper.php
@@ -92,27 +92,27 @@ class CalendarHelper
 	 * @param type $link
 	 * @return type
 	 */
-	public static function add_preview_params($link,$object)
-	{
-		// Pass through if not logged in
-		if(!Member::currentUserID()) {
-			return $link;
-		}
-		$modifiedLink = '';
-		$request = Controller::curr()->getRequest();
-		if ($request && $request->getVar('CMSPreview')) {
-			// Preserve the preview param for further links
-			$modifiedLink = HTTP::setGetVar('CMSPreview', 1, $link);
-			// Quick fix - multiple uses of setGetVar method double escape the ampersands
-			$modifiedLink = str_replace('&amp;','&',$modifiedLink); 
-			// Add SubsiteID, if applicable
-			if (!empty($object->SubsiteID)) {
-				$modifiedLink = HTTP::setGetVar('SubsiteID', $object->SubsiteID, $modifiedLink);
-				// Quick fix - multiple uses of setGetVar method double escape the ampersands
-				$modifiedLink = str_replace('&amp;','&',$modifiedLink); 
-			}
-		} 
-   
-		return ($modifiedLink) ? $modifiedLink : $link;
-	}
+    public static function add_preview_params($link,$object)
+    {
+        // Pass through if not logged in
+        if(!Member::currentUserID()) {
+            return $link;
+        }
+        $modifiedLink = '';
+        $request = Controller::curr()->getRequest();
+        if ($request && $request->getVar('CMSPreview')) {
+            // Preserve the preview param for further links
+            $modifiedLink = HTTP::setGetVar('CMSPreview', 1, $link);
+            // Quick fix - multiple uses of setGetVar method double escape the ampersands
+            $modifiedLink = str_replace('&amp;','&',$modifiedLink); 
+            // Add SubsiteID, if applicable
+            if (!empty($object->SubsiteID)) {
+                $modifiedLink = HTTP::setGetVar('SubsiteID', $object->SubsiteID, $modifiedLink);
+                // Quick fix - multiple uses of setGetVar method double escape the ampersands
+                $modifiedLink = str_replace('&amp;','&',$modifiedLink); 
+            }
+        } 
+
+        return ($modifiedLink) ? $modifiedLink : $link;
+    }
 }

--- a/code/events/PublicEvent.php
+++ b/code/events/PublicEvent.php
@@ -21,8 +21,6 @@ class PublicEvent extends Event
      */
     public function getInternalLink()
     {
-        $detailStr = 'detail/' . $this->ID;
-
         //for now all event details will only have one link - that is the main calendar page
         //NOTE: this could be amended by calling that link via AJAX, and thus could be shown as an overlay
         //everywhere on the site
@@ -38,7 +36,7 @@ class PublicEvent extends Event
 //			}
 //		} else {
             $calendarPage = CalendarPage::get()->First();
-        return $calendarPage->Link(). $detailStr;
+        return CalendarHelper::add_preview_params(Controller::join_links($calendarPage->Link('detail'),$this->ID),$this);
 //		}
     }
 }

--- a/code/events/PublicEvent.php
+++ b/code/events/PublicEvent.php
@@ -35,7 +35,7 @@ class PublicEvent extends Event
 //				return $calendarPage->Link() .  $detailStr;
 //			}
 //		} else {
-            $calendarPage = CalendarPage::get()->First();
+        $calendarPage = CalendarPage::get()->First();
         return CalendarHelper::add_preview_params(Controller::join_links($calendarPage->Link('detail'),$this->ID),$this);
 //		}
     }

--- a/code/pagetypes/CalendarPage.php
+++ b/code/pagetypes/CalendarPage.php
@@ -100,8 +100,9 @@ class CalendarPage_Controller extends Page_Controller
 
             Requirements::javascript('calendar/javascript/fullcalendar/PublicFullcalendarView.js');
 
-            $url = $this->Link();
+            $url = CalendarHelper::add_preview_params($this->Link(),$this->data());
             $fullcalendarjs = $s['calendarpage']['fullcalendar_js_settings'];
+			$controllerUrl = CalendarHelper::add_preview_params($s['calendarpage']['controllerUrl'],$this->data());
 
             //shaded events
             $shadedEvents = 'false';
@@ -109,13 +110,14 @@ class CalendarPage_Controller extends Page_Controller
             if ($sC['shading']) {
                 $shadedEvents = 'true';
             }
-
+			
             //Calendar initialization (and possibility for later configuration options)
             Requirements::customScript("
 				(function($) {
 					$(function () {
 						//Initializing fullcalendar
 						var cal = new PublicFullcalendarView($('#calendar'), '$url', {
+							controllerUrl: '$controllerUrl',
 							fullcalendar: {
 								$fullcalendarjs
 							},
@@ -303,8 +305,9 @@ class CalendarPage_Controller extends Page_Controller
     public function NextMonthLink()
     {
         $month = $this->NextMonth();
-        $url = $this->Link() . $this->request->param('Action') . '/?month=' . $month;
-        return $url;
+        $url = $this->Link($this->request->param('Action'));
+		$url = HTTP::setGetVar('month',$month,$url);
+        return CalendarHelper::add_preview_params($url,$this->data());
     }
     public function PrevMonth()
     {
@@ -318,8 +321,9 @@ class CalendarPage_Controller extends Page_Controller
     public function PrevMonthLink()
     {
         $month = $this->PrevMonth();
-        $url = $this->Link() . $this->request->param('Action') . '/?month=' . $month;
-        return $url;
+		$url = $this->Link($this->request->param('Action'));
+		$url = HTTP::setGetVar('month',$month,$url);
+		return CalendarHelper::add_preview_params($url,$this->data());
     }
 
 
@@ -327,22 +331,20 @@ class CalendarPage_Controller extends Page_Controller
     {
         $s = CalendarConfig::subpackage_settings('pagetypes');
         $indexSetting = $s['calendarpage']['index'];
-        $link = $this->Link();
         if ($indexSetting == 'eventlist') {
-            return $link;
+            return CalendarHelper::add_preview_params($this->Link(),$this->data());
         } elseif ($indexSetting == 'calendarview') {
-            return $link . 'eventlist/';
+            return CalendarHelper::add_preview_params($this->Link('eventlist'),$this->data());
         }
     }
     public function CalendarViewLink()
     {
         $s = CalendarConfig::subpackage_settings('pagetypes');
         $indexSetting = $s['calendarpage']['index'];
-        $link = $this->Link();
         if ($indexSetting == 'eventlist') {
-            return $link . 'calendarview/';
+            return CalendarHelper::add_preview_params($this->Link('calendarview'),$this->data());
         } elseif ($indexSetting == 'calendarview') {
-            return $link;
+            return CalendarHelper::add_preview_params($this->Link(),$this->data());
         }
     }
 
@@ -362,4 +364,11 @@ class CalendarPage_Controller extends Page_Controller
         $calendars = PublicCalendar::get();
         return $calendars;
     }
+	
+	public function FeedLink($calendarID)
+	{
+		$calendar = Calendar::get()->byID(intval($calendarID));
+		$url = Controller::join_links($this->Link(),'calendar',($calendar) ? $calendar->Link : '');
+		return CalendarHelper::add_preview_params($url,$this->data());
+	}
 }

--- a/code/pagetypes/CalendarPage.php
+++ b/code/pagetypes/CalendarPage.php
@@ -306,7 +306,7 @@ class CalendarPage_Controller extends Page_Controller
     {
         $month = $this->NextMonth();
         $url = $this->Link($this->request->param('Action'));
-		$url = HTTP::setGetVar('month',$month,$url);
+        $url = HTTP::setGetVar('month',$month,$url);
         return CalendarHelper::add_preview_params($url,$this->data());
     }
     public function PrevMonth()
@@ -322,7 +322,7 @@ class CalendarPage_Controller extends Page_Controller
     {
         $month = $this->PrevMonth();
 		$url = $this->Link($this->request->param('Action'));
-		$url = HTTP::setGetVar('month',$month,$url);
+        $url = HTTP::setGetVar('month',$month,$url);
 		return CalendarHelper::add_preview_params($url,$this->data());
     }
 
@@ -365,10 +365,10 @@ class CalendarPage_Controller extends Page_Controller
         return $calendars;
     }
 	
-	public function FeedLink($calendarID)
-	{
-		$calendar = Calendar::get()->byID(intval($calendarID));
-		$url = Controller::join_links($this->Link(),'calendar',($calendar) ? $calendar->Link : '');
-		return CalendarHelper::add_preview_params($url,$this->data());
-	}
+    public function FeedLink($calendarID)
+    {
+        $calendar = Calendar::get()->byID(intval($calendarID));
+        $url = Controller::join_links($this->Link(),'calendar',($calendar) ? $calendar->Link : '');
+        return CalendarHelper::add_preview_params($url,$this->data());
+    }
 }

--- a/code/subsites/AbstractSubsiteExtension.php
+++ b/code/subsites/AbstractSubsiteExtension.php
@@ -1,12 +1,14 @@
 <?php
 
-abstract class AbstractSubsiteExtension extends DataExtension {
-	
-	public function updateCMSFields(FieldList $fields) {
-		$fields->push(HiddenField::create('SubsiteID','SubsiteID',Subsite::currentSubsiteID()));
-	}
-	
-	/**
+abstract class AbstractSubsiteExtension extends DataExtension
+{
+
+    public function updateCMSFields(FieldList $fields)
+    {
+        $fields->push(HiddenField::create('SubsiteID', 'SubsiteID', Subsite::currentSubsiteID()));
+    }
+
+    /**
      * Update any requests to limit the results to the current site
      */
     public function augmentSQL(SQLQuery &$query)
@@ -15,22 +17,20 @@ abstract class AbstractSubsiteExtension extends DataExtension {
             return;
         }
 
-		// Filter by subsite
-		$ids = array((int) Subsite::currentSubsiteID());
+        // Filter by subsite
+        $ids = array((int) Subsite::currentSubsiteID());
 
-		// If configured to treat subsite 0 as global, include ID 0.
-		if(Config::inst()->get('LeftAndMain','treats_subsite_0_as_global')) {
-			$ids[] = 0;
-		}
-		$ids = implode(',',$ids);
-		
-		// The foreach is an ugly way of getting the first key
+        // If configured to treat subsite 0 as global, include ID 0.
+        if (Config::inst()->get('LeftAndMain', 'treats_subsite_0_as_global')) {
+            $ids[] = 0;
+        }
+        $ids = implode(',', $ids);
+
+        // The foreach is an ugly way of getting the first key
         foreach ($query->getFrom() as $tableName => $info) {
             $where = "\"$tableName\".\"SubsiteID\" IN ($ids)";
             $query->addWhere($where);
             break;
         }
-
     }
-	
 }

--- a/code/subsites/AbstractSubsiteExtension.php
+++ b/code/subsites/AbstractSubsiteExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+abstract class AbstractSubsiteExtension extends DataExtension {
+	
+	public function updateCMSFields(FieldList $fields) {
+		$fields->push(HiddenField::create('SubsiteID','SubsiteID',Subsite::currentSubsiteID()));
+	}
+	
+	/**
+     * Update any requests to limit the results to the current site
+     */
+    public function augmentSQL(SQLQuery &$query)
+    {
+        if (Subsite::$disable_subsite_filter) {
+            return;
+        }
+
+		// Filter by subsite
+		$ids = array((int) Subsite::currentSubsiteID());
+
+		// If configured to treat subsite 0 as global, include ID 0.
+		if(Config::inst()->get('LeftAndMain','treats_subsite_0_as_global')) {
+			$ids[] = 0;
+		}
+		$ids = implode(',',$ids);
+		
+		// The foreach is an ugly way of getting the first key
+        foreach ($query->getFrom() as $tableName => $info) {
+            $where = "\"$tableName\".\"SubsiteID\" IN ($ids)";
+            $query->addWhere($where);
+            break;
+        }
+
+    }
+	
+}

--- a/code/subsites/CalendarSubsiteExtension.php
+++ b/code/subsites/CalendarSubsiteExtension.php
@@ -1,0 +1,9 @@
+<?php
+
+class CalendarSubsiteExtension extends AbstractSubsiteExtension {
+	
+	private static $has_one = array(
+		'Subsite' => 'Subsite'		
+	);
+	
+}

--- a/code/subsites/CalendarSubsiteExtension.php
+++ b/code/subsites/CalendarSubsiteExtension.php
@@ -1,9 +1,10 @@
 <?php
 
-class CalendarSubsiteExtension extends AbstractSubsiteExtension {
-	
-	private static $has_one = array(
-		'Subsite' => 'Subsite'		
-	);
-	
+class CalendarSubsiteExtension extends AbstractSubsiteExtension
+{
+
+    private static $has_one = array(
+        'Subsite' => 'Subsite'
+    );
+
 }

--- a/code/subsites/EventCategorySubsiteExtension.php
+++ b/code/subsites/EventCategorySubsiteExtension.php
@@ -1,0 +1,9 @@
+<?php
+
+class EventCategorySubsiteExtension extends AbstractSubsiteExtension {
+	
+	private static $has_one = array(
+		'Subsite' => 'Subsite'		
+	);
+	
+}

--- a/code/subsites/EventCategorySubsiteExtension.php
+++ b/code/subsites/EventCategorySubsiteExtension.php
@@ -1,9 +1,10 @@
 <?php
 
-class EventCategorySubsiteExtension extends AbstractSubsiteExtension {
-	
-	private static $has_one = array(
-		'Subsite' => 'Subsite'		
-	);
-	
+class EventCategorySubsiteExtension extends AbstractSubsiteExtension
+{
+
+    private static $has_one = array(
+        'Subsite' => 'Subsite'
+    );
+
 }

--- a/code/subsites/EventSubsiteExtension.php
+++ b/code/subsites/EventSubsiteExtension.php
@@ -1,9 +1,10 @@
 <?php
 
-class EventSubsiteExtension extends AbstractSubsiteExtension {
-	
-	private static $has_one = array(
-		'Subsite' => 'Subsite'		
-	);
-	
+class EventSubsiteExtension extends AbstractSubsiteExtension
+{
+
+    private static $has_one = array(
+        'Subsite' => 'Subsite'
+    );
+
 }

--- a/code/subsites/EventSubsiteExtension.php
+++ b/code/subsites/EventSubsiteExtension.php
@@ -1,0 +1,9 @@
+<?php
+
+class EventSubsiteExtension extends AbstractSubsiteExtension {
+	
+	private static $has_one = array(
+		'Subsite' => 'Subsite'		
+	);
+	
+}

--- a/templates/Includes/EventDetail.ss
+++ b/templates/Includes/EventDetail.ss
@@ -5,7 +5,7 @@
 			<div class="feedBox">
 				<% if $Calendar %>
 					<% with $Calendar %>
-						<a href="{$Top.Link}calendar/$Link/" class="feed-checkbox" original-title="Subscribe to this Calendar on your Home computer or Mobile Phone" style="background-color:$ColorWithHash;"></a>
+						<a href="{$Top.FeedLink($ID)}" class="feed-checkbox" original-title="Subscribe to this Calendar on your Home computer or Mobile Phone" style="background-color:$ColorWithHash;"></a>
 					<% end_with %>
 				<% end_if %>
 			</div>

--- a/templates/Includes/EventListEvents.ss
+++ b/templates/Includes/EventListEvents.ss
@@ -3,7 +3,7 @@
 		<div class="feedBox">
 			<% if $Calendar %>
 				<% with $Calendar %>
-					<a href="{$Top.Link}calendar/$Link/" class="feed-checkbox" original-title="Subscribe to this Calendar on your Home computer or Mobile Phone" style="background-color:$ColorWithHash;"></a>
+					<a href="{$Top.FeedLink($ID)}" class="feed-checkbox" original-title="Subscribe to this Calendar on your Home computer or Mobile Phone" style="background-color:$ColorWithHash;"></a>
 				<% end_with %>
 			<% end_if %>
 		</div>


### PR DESCRIPTION
Previously there was no support for subsites. This pull request adds support for subsite filtering and subsite previews. 
Specifically...
Added extensions to provide subsite relation and filtering for Calendar, Event, and EventCategory models. Updates to link methods in CalendarPage and JS to support CMS and subsite previews. Added method to Calendar helper which adds preview params to links. Revised option handling in PublicFullcalendarView.js to allow  more customisation via config, including calendar controllerUrl. Added FeedLink method to CalendarPage, and revised associated templates.