### PR TITLE
Basic permissions

### DIFF
--- a/code/admin/CalendarAdmin.php
+++ b/code/admin/CalendarAdmin.php
@@ -5,7 +5,7 @@
  * @package calendar
  * @subpackage admin
  */
-class CalendarAdmin extends LeftAndMain
+class CalendarAdmin extends LeftAndMain implements PermissionProvider
 {
 
     public static $menu_title = "Calendar";
@@ -167,4 +167,31 @@ class CalendarAdmin extends LeftAndMain
             return $this->getResponseNegotiator()->respond($request);
         }
     }
+	
+	
+	public function providePermissions() {
+		$title = LeftAndMain::menu_title_for_class($this->class);
+		return array(
+			"CMS_ACCESS_CalendarAdmin" => array(
+				'name' => _t('CMSMain.ACCESS', "Access to '{title}' section", array('title' => $title)),
+				'category' => _t('Permission.CMS_ACCESS_CATEGORY', 'CMS Access'),
+				'help' => 'Allow access to calendar management module.'
+			),
+			"CALENDAR_MANAGE" => array(
+				'name' => _t('CalendarAdmin.CALENDAR_MANAGE', 'Manage calendars'),
+				'category' => _t('CalendarAdmin.CALENDAR_PERMISSION_CATEGORY', 'Calender'),
+				'help' => 'Allow creating, editing, and deleting calendars.'
+			),
+			"EVENTCATEGORY_MANAGE" => array(
+				'name' => _t('CalendarAdmin.EVENTCATEGORY_MANAGE', 'Manage event categories'),
+				'category' => _t('CalendarAdmin.CALENDAR_PERMISSION_CATEGORY', 'Calender'),
+				'help' => 'Allow creating, editing, and deleting event categories.'
+			),
+			"EVENT_MANAGE" => array(
+				'name' => _t('CalendarAdmin.EVENT_MANAGE', 'Manage events'),
+				'category' => _t('CalendarAdmin.CALENDAR_PERMISSION_CATEGORY', 'Calender'),
+				'help' => 'Allow creating, editing, and deleting events.'
+			)
+		);
+	}
 }

--- a/code/calendars/PublicCalendar.php
+++ b/code/calendars/PublicCalendar.php
@@ -11,4 +11,55 @@ class PublicCalendar extends Calendar
     //Public calendars are simpley called 'Calendar'
     public static $singular_name = 'Calendar';
     public static $plural_name = 'Calendars';
+	
+	/**
+	 * 
+	 * Anyone can view public calendar
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canView($member = null)
+	{
+		return true;
+	}
+	
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canCreate($member = null)
+    {
+        return $this->canManage($member);
+    }
+	
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canEdit($member = null)
+    {
+        return $this->canManage($member);
+    }
+
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+    public function canDelete($member = null)
+    {
+        return $this->canManage($member);
+    }
+
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	protected function canManage($member)
+	{
+		return Permission::check('ADMIN','any',$member) || Permission::check('CALENDAR_MANAGE','any',$member);
+	}
 }

--- a/code/categories/PublicEventCategory.php
+++ b/code/categories/PublicEventCategory.php
@@ -17,4 +17,54 @@ class PublicEventCategory extends EventCategory
             );
         return $events;
     }
+	
+	/**
+	 * Anyone can view public event categories
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canView($member = null)
+	{
+		return true;
+	}
+
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canCreate($member = null)
+    {
+        return $this->canManage($member);
+    }
+	
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canEdit($member = null)
+    {
+        return $this->canManage($member);
+    }
+
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+    public function canDelete($member = null)
+    {
+        return $this->canManage($member);
+    }
+
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	protected function canManage($member)
+	{
+		return Permission::check('ADMIN','any',$member) || Permission::check('EVENTCATEGORY_MANAGE','any',$member);
+	}
 }

--- a/code/events/PublicEvent.php
+++ b/code/events/PublicEvent.php
@@ -41,4 +41,54 @@ class PublicEvent extends Event
         return $calendarPage->Link(). $detailStr;
 //		}
     }
+
+	/**
+	 * Anyone can view public events
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canView($member = null)
+	{
+		return true;
+	}
+	
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canCreate($member = null)
+    {
+        return $this->canManage($member);
+    }
+	
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canEdit($member = null)
+    {
+        return $this->canManage($member);
+    }
+
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+    public function canDelete($member = null)
+    {
+        return $this->canManage($member);
+    }
+
+	/**
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	protected function canManage($member)
+	{
+		return Permission::check('ADMIN','any',$member) || Permission::check('EVENT_MANAGE','any',$member);
+	}
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,6 @@
+en:
+  CalendarAdmin:
+    CALENDAR_PERMISSION_CATEGORY: 'Calendar'
+    CALENDAR_MANAGE: 'Manage calendars'
+    EVENTCATEGORY_MANAGE: 'Manage event categories'
+    EVENT_MANAGE: 'Manage events'


### PR DESCRIPTION
Previously, only admins have access to the event calendar. This request adds basic access permissions to allow admins to grant permissions to other roles/groups to access the calendar and manage public events.

Specifically... added module access permission for CalendarAdmin. Added basic access permissions for the public models. Added associated language entries.