### PR TITLE
Fixed default model form class

### DIFF
--- a/code/admin/CalendarAdmin.php
+++ b/code/admin/CalendarAdmin.php
@@ -73,8 +73,10 @@ class CalendarAdmin extends ModelAdmin implements PermissionProvider
                 $class = 'CategoriesForm';
 				break;
             case 'PublicEvent':
-            default:
                 $class = 'EventsForm';
+				break;
+            default:
+                $class = 'CMSForm';
 				break;
 		}
         


### PR DESCRIPTION
This request corrects the default form class for CalendarAdmin, so CalendarAdmin will not have an issue when other managed models are added by other modules, such as the EventLocation (venue) model added by https://github.com/ToddHossack/silverstripe-calendar-locations